### PR TITLE
Fix DEALING_ID issue: preserve original Dealing_no

### DIFF
--- a/data-raw/etl-2015-fix.R
+++ b/data-raw/etl-2015-fix.R
@@ -64,13 +64,7 @@ cat("Deduplicated:", before, "->", after, "\n")
 # Order
 setorder(dat, Settlement_date, Property_id)
 
-# DEALING_ID
-if ("Dealing_no" %in% names(dat)) {
-  dealing_map <- dat[, .(Dealing_no)] |> unique()
-  dealing_map[, DEALING_ID := .I]
-  dat <- dealing_map[dat, on = "Dealing_no"]
-  dat[, Dealing_no := NULL]
-}
+# Keep original Dealing_no (per-year DEALING_ID would break surrogate key purpose)
 
 # Reorder columns
 setcolorder(dat, c("Settlement_date", "Property_id"))

--- a/data-raw/etl-yearly.R
+++ b/data-raw/etl-yearly.R
@@ -173,13 +173,7 @@ process_post2001 <- function(all_b_file, year) {
     setorder(dat, Settlement_date, Property_id)
   }
 
-  # Convert Dealing_no to DEALING_ID (per-year IDs)
-  if ("Dealing_no" %in% names(dat)) {
-    dealing_map <- dat[, .(Dealing_no)] |> unique()
-    dealing_map[, DEALING_ID := .I]
-    dat <- dealing_map[dat, on = "Dealing_no"]
-    dat[, Dealing_no := NULL]
-  }
+  # Keep original Dealing_no (per-year DEALING_ID would break surrogate key purpose)
 
   # Reorder columns
   first_cols <- c("Settlement_date", "Property_id")


### PR DESCRIPTION
Fixes #2 (item 2): Per-year DEALING_ID broke the surrogate key purpose because the same dealing number got different IDs across years.

Now preserves the original Dealing_no column instead of converting to a per-year integer ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)